### PR TITLE
Allow linking to specific lines in files

### DIFF
--- a/src/MDLinkLinter/Assertion/RelativeLink.php
+++ b/src/MDLinkLinter/Assertion/RelativeLink.php
@@ -57,6 +57,9 @@ final class RelativeLink implements Assertion
                 continue;
             }
 
+            // GitHub allows to link to specific lines in files
+            $path = \preg_replace('/([#L0-9]+?)$/', '', $path);
+
             if (\file_exists($path)) {
                 $logger->debug(\sprintf('Relative Link %s points to valid existing file: %s', $this->link->text(), $path));
 

--- a/tests/MDLinkLinter/Tests/Console/fixtures/with_relative/src/element/README.md
+++ b/tests/MDLinkLinter/Tests/Console/fixtures/with_relative/src/element/README.md
@@ -1,1 +1,1 @@
-[relative](src/file.txt)
+[relative](src/file.txt) and [relative with anchor](src/file.txt#L3)

--- a/tests/MDLinkLinter/Tests/Console/fixtures/with_relative/src/element/src/file.txt
+++ b/tests/MDLinkLinter/Tests/Console/fixtures/with_relative/src/element/src/file.txt
@@ -1,0 +1,3 @@
+Line 1
+Line 2
+Line 3


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Something that makes everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Allow linking to specific lines in files</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something old or redundant</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something that is no more needed</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that wasn't secure</li> -->
  </ul>     
</div>
<hr/> 

### Changes Description

GitHub allows us to link to specific lines in code, like [line 7 in `composer.json`](https://github.com/norberttech/md-link-linter/blob/1.x/composer.json#L7) file.